### PR TITLE
ci: pass the version through env in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Check if tag exists
         id: check-tag
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION=${{ steps.get-version.outputs.version }}
           if git ls-remote --tags origin | grep -q "refs/tags/v${VERSION}$"; then
             echo "This version v${VERSION} has been released"
             echo "should_release=false" >> $GITHUB_OUTPUT
@@ -50,10 +51,12 @@ jobs:
       - name: Create Release
         id: create-release
         uses: actions/github-script@v7
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
         with:
           script: |
             const fs = require('fs');
-            const version = '${{ needs.check-version.outputs.version }}';
+            const version = process.env.VERSION;
 
             // 从 CHANGELOG.md 提取当前版本段落
             let changelog = '';


### PR DESCRIPTION
### What

`.github/workflows/publish.yml` uses the `package.json` version in two places where it is treated as code rather than data.

**1. Shell, unquoted:**

```yaml
run: |
  VERSION=${{ steps.get-version.outputs.version }}
```

`${{ ... }}` is substituted as text before bash parses the line, and the assignment is unquoted, so a version string containing shell metacharacters is executed rather than assigned.

**2. JavaScript source:**

```js
const version = '${{ needs.check-version.outputs.version }}';
```

The `script:` block is JavaScript, and the expansion happens before it is parsed, so a single quote in the version closes the string literal and the rest is evaluated as code — in the `create-release` job, which holds `contents: write`.

### Why this looked worth reporting

The file already does exactly the right thing three times over — `RELEASE_ID` is passed via `env:` and read with `process.env.RELEASE_ID` in the upload, docker and notify steps. These two are the outliers, so this is a consistency gap rather than a design disagreement.

**On severity:** the workflow triggers only on `push` to `pro`, so reaching it requires a change to `package.json` landing on that branch. This is **defense in depth, not an externally reachable vulnerability.**

### The fix

Pass the version through `env:` in both places, matching the existing `RELEASE_ID` handling. In the shell step the explicit `VERSION=` assignment is no longer needed, since `env` provides it and the rest of the block already reads `${VERSION}`. Behaviour is unchanged.

### Verification

The workflow parses cleanly and no `${{ }}` expansion remains inside any `run:` or `script:` body.

### AI assistance

I used an AI coding agent to sweep release workflows for this pattern and to draft this description. What I confirmed in the file myself, rather than accepted from a model: that `RELEASE_ID` is already passed through `env:` and read with `process.env.RELEASE_ID` in the upload, docker and notify steps — which is what makes these two an inconsistency inside your own file rather than a style preference of mine — and that the only trigger is `push` to `pro`, which is the basis for the severity note above.
